### PR TITLE
Create post page code generation

### DIFF
--- a/blog_system/src/app/create-post/page.tsx
+++ b/blog_system/src/app/create-post/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import PostForm from "@/components/PostForm";
+
+export default function CreatePostPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/login");
+    }
+  }, [status, router]);
+
+  if (status === "loading") {
+    return <div className="max-w-2xl mx-auto mt-10">Loading...</div>;
+  }
+
+  if (!session) {
+    return null;
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto mt-10 p-4">
+      <h1 className="text-2xl font-bold mb-4">Create New Post</h1>
+      <PostForm onPostCreated={() => router.push("/")} />
+    </div>
+  );
+}

--- a/blog_system/src/app/page.tsx
+++ b/blog_system/src/app/page.tsx
@@ -9,6 +9,7 @@ export type PostListItem = {
   imageUrl?: string | null;
   likes?: Array<unknown>;
   comments?: Array<unknown>;
+  _count?: { likes?: number; comments?: number };
 };
 
 async function getPosts(): Promise<PostListItem[]> {

--- a/blog_system/src/components/PostCard.tsx
+++ b/blog_system/src/components/PostCard.tsx
@@ -5,10 +5,21 @@ import { useState } from "react";
 import Link from "next/link";
 import type { PostListItem } from "@/app/page";
 
-type PostCardProps = { post: PostListItem & { likesCount?: number } };
+type PostCardProps = {
+  post: PostListItem & {
+    _count?: { likes?: number; comments?: number };
+    likesCount?: number;
+  };
+};
 
 export default function PostCard({ post }: PostCardProps) {
-  const [likes, setLikes] = useState<number>(post.likesCount || 0);
+  const initialLikes =
+    (post._count?.likes ??
+      (Array.isArray(post.likes) ? post.likes.length : undefined) ??
+      post.likesCount ??
+      0) as number;
+
+  const [likes, setLikes] = useState<number>(initialLikes);
 
   const handleLike = async () => {
     try {


### PR DESCRIPTION
Adds a new 'Create Post' page at `/create-post` that reuses `PostForm` and handles authentication.

---
<a href="https://cursor.com/background-agent?bcId=bc-a901cabb-f123-4a08-81d6-3daa097f4c0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a901cabb-f123-4a08-81d6-3daa097f4c0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

